### PR TITLE
feat(support): dump pending posts on launch

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -57,6 +57,12 @@
         <config-file parent="ITSAppUsesNonExemptEncryption" platform="ios" target="*-Info.plist">
             <false />
         </config-file>
+        <config-file parent="UIFileSharingEnabled" target="*-Info.plist">
+            <true />
+        </config-file>
+         <config-file parent="LSSupportsOpeningDocumentsInPlace" target="*-Info.plist">
+            <true />
+        </config-file>
         <config-file parent="NSCameraUsageDescription" platform="ios" target="*-Info.plist">
             <string>This app would like to access the camera, so you can to take photos for your reports.</string>
         </config-file>
@@ -150,7 +156,7 @@
     <preference name="AllowInlineMediaPlayback" value="true" />
     <preference name="CordovaWebViewEngine" value="CDVWKWebViewEngine" />
     <preference name="MediaPlaybackRequiresUserAction" value="true" />
-    <preference name="iosPersistentFileLocation" value="Compatibility" />
+    <preference name="iosPersistentFileLocation" value="Library" />
     <preference name="AndroidPersistentFileLocation" value="Compatibility" />
     <preference name="iosExtraFilesystems" value="library,library-nosync,documents,documents-nosync,cache,bundle,root" />
     <preference name="AndroidExtraFilesystems" value="files,files-external,documents,sdcard,cache,cache-external,assets,root" />
@@ -226,9 +232,7 @@
     <plugin name="cordova.plugins.diagnostic" spec="^4.0.12">
         <variable name="ANDROID_SUPPORT_VERSION" value="28.+" />
     </plugin>
-    <plugin name="cordova-plugin-google-analytics" spec="^1.8.6">
-        <variable name="GMS_VERSION" value="11.0.1" />
-    </plugin>
+    <plugin name="cordova-plugin-google-analytics" spec="^1.8.6" />
     <engine name="ios" spec="~5.1.1" />
     <engine name="android" spec="~9.0.0" />
 </widget>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -336,11 +336,7 @@ export class UshahidiApp {
 
   private loadDatabase(models:Model[]):Promise<any> {
     this.logger.info(this, "loadDatabase");
-    var db = this.database.loadDatabase(models);
-    window['getDatabase'] = () => {
-      return this.database;
-    }
-    return db;
+    return this.database.loadDatabase(models);
   }
 
   private resetDatabase():Promise<any> {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -28,6 +28,7 @@ import { DatabaseService } from '../providers/database-service';
 import { InjectorService } from '../providers/injector-service';
 import { LanguageService } from '../providers/language-service';
 import { SettingsService } from '../providers/settings-service';
+import { SupportService } from '../providers/support-service';
 
 import { DeploymentNonePage } from '../pages/deployment-none/deployment-none';
 import { DeploymentSearchPage } from '../pages/deployment-search/deployment-search';
@@ -96,6 +97,7 @@ export class UshahidiApp {
     private database:DatabaseService,
     private language:LanguageService,
     private settings:SettingsService,
+    private supportService:SupportService,
     private modalController:ModalController,
     private toastController:ToastController,
     private loadingController:LoadingController,
@@ -189,7 +191,12 @@ export class UshahidiApp {
           },
           (error:any) => {
             this.showRootPage();
-          });
+          })
+        .then(
+          () => {
+            this.supportService.dumpPendingPosts()
+          }
+        );
       },
       (error:any) => {
         this.splashScreen.hide();
@@ -329,7 +336,11 @@ export class UshahidiApp {
 
   private loadDatabase(models:Model[]):Promise<any> {
     this.logger.info(this, "loadDatabase");
-    return this.database.loadDatabase(models);
+    var db = this.database.loadDatabase(models);
+    window['getDatabase'] = () => {
+      return this.database;
+    }
+    return db;
   }
 
   private resetDatabase():Promise<any> {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -90,6 +90,7 @@ import { DatabaseService } from '../providers/database-service';
 import { CacheService } from '../providers/cache-service';
 import { LanguageService } from '../providers/language-service';
 import { SettingsService } from '../providers/settings-service';
+import { SupportService } from '../providers/support-service';
 
 export function fallbackTranslateLoader(http:HttpClient):TranslateLoader {
     return new FallbackTranslateLoader(http, 'assets/i18n/', '.json');
@@ -249,6 +250,7 @@ export class CustomErrorHandler extends IonicErrorHandler implements ErrorHandle
     { provide: LanguageService, useClass: LanguageService },
     { provide: TranslateService, useClass: TranslateService },
     { provide: SettingsService, useClass: SettingsService },
+    { provide: SupportService, useClass: SupportService },
     { provide: ErrorHandler, useClass: CustomErrorHandler }
   ]
 })

--- a/src/providers/support-service.ts
+++ b/src/providers/support-service.ts
@@ -33,15 +33,18 @@ export class SupportService {
   // Android:
   //   Internal Storage > Android > data > com.ushahidi.mobile > files > support
   // iOS:
-  //   
+  //   Files > On My iPhone > Ushahidi > support
   protected supportFolder():Promise<DirectoryEntry> {
     var root:string;
+    this.logger.info(this, 'supportFolder', 'Current platforms', this.platform.platforms());
     if (this.platform.is("android")) {
       // On Android, use the externalDataDirectory
       root = this.file.externalDataDirectory;
+      this.logger.info(this, 'supportFolder', 'Platform is Android, setting root to', root);
     } else if (this.platform.is("ios")) {
-      // On iOS, use dataDirectory
-      root = this.file.dataDirectory;
+      // On iOS, use documentsDirectory
+      root = this.file.documentsDirectory;
+      this.logger.info(this, 'supportFolder', 'Platform is iOS, setting root to', root);
     }
     return new Promise<DirectoryEntry>((resolve, reject) => {
       this.file.resolveDirectoryUrl(root).then(
@@ -58,6 +61,7 @@ export class SupportService {
     return new Promise<FileWriter>((resolve, reject) => {
       this.supportFolder().then(
         (folder:DirectoryEntry) => {
+          this.logger.info(this, 'supportFile', 'Got support folder at: ', folder);
           folder.getFile(name, {create: true, exclusive: true},
             (entry:FileEntry) => {
               entry.createWriter((w:FileWriter) => resolve(w), (err) => reject(err));

--- a/src/providers/support-service.ts
+++ b/src/providers/support-service.ts
@@ -1,0 +1,153 @@
+import { Injectable } from '@angular/core';
+import { Platform } from 'ionic-angular';
+
+import { File, DirectoryEntry, Entry, FileEntry, FileWriter, DirectoryReader } from '@ionic-native/file';
+import { NativeStorage } from '@ionic-native/native-storage';
+
+import { Deployment } from '../models/deployment';
+import { Post } from '../models/post';
+import { Value } from '../models/value';
+import { User } from '../models/user';
+import { Form } from '../models/form';
+
+
+import { DatabaseService } from '../providers/database-service';
+import { LoggerService } from '../providers/logger-service';
+import { writeToNodes } from 'ionic-angular/umd/components/virtual-scroll/virtual-util';
+
+/*
+ * Class containing useful methods for diagnostic and user support tasks
+ */
+@Injectable()
+export class SupportService {
+
+  constructor(
+    protected file:File,
+    protected logger:LoggerService,
+    protected storage: NativeStorage,
+    protected database:DatabaseService,
+    protected platform:Platform) {
+  }
+
+  // Gets/creates support folder, locations where it will be found:
+  // Android:
+  //   Internal Storage > Android > data > com.ushahidi.mobile > files > support
+  // iOS:
+  //   
+  protected supportFolder():Promise<DirectoryEntry> {
+    var root:string;
+    if (this.platform.is("android")) {
+      // On Android, use the externalDataDirectory
+      root = this.file.externalDataDirectory;
+    } else if (this.platform.is("ios")) {
+      // On iOS, use dataDirectory
+      root = this.file.dataDirectory;
+    }
+    return new Promise<DirectoryEntry>((resolve, reject) => {
+      this.file.resolveDirectoryUrl(root).then(
+        (entry) => entry.getDirectory('support',
+          { create: true },
+          (entry:DirectoryEntry) => resolve(entry),
+          (err) => reject(err)
+        )
+      )
+    });
+  }
+
+  protected supportFile(dir:DirectoryEntry, name:string):Promise<FileWriter> {
+    return new Promise<FileWriter>((resolve, reject) => {
+      this.supportFolder().then(
+        (folder:DirectoryEntry) => {
+          folder.getFile(name, {create: true, exclusive: true},
+            (entry:FileEntry) => {
+              entry.createWriter((w:FileWriter) => resolve(w), (err) => reject(err));
+            }, (err) => reject(err))
+      });
+    });
+  }
+
+  protected supportFileRotate(folder:DirectoryEntry, name:string) {
+    const KEEP_N_FILES = 20;
+    folder.createReader().readEntries(
+      (entries: Entry[]) => {
+        let matches:Entry[] = entries.filter(
+          (e:Entry) => e.name.match(new RegExp(`^${name}.\\d+.txt$`))
+        );
+        matches.sort(
+          (a,b) => (a.name === b.name) ? 0 : (a.name < b.name) ? -1 : 1
+        )
+        if (matches.length > KEEP_N_FILES) {
+          let toDelete:Entry[] = matches.slice(0, -KEEP_N_FILES);
+          toDelete.forEach(
+            (e:Entry) => e.remove(
+              ()=>{},
+              (err) => this.logger.info(this, 'supportFileRotate', err)
+            ));
+        }
+      },
+      (err) => this.logger.info(this, 'supportFileRotate', err)
+    );
+  }
+
+  protected supportFileCreateRotate(name:string):Promise<FileWriter> {
+    return this.supportFolder().then(
+      (folder:DirectoryEntry) => {
+        this.supportFileRotate(folder, name);
+        let newName:string = `${name}.${new Date().getTime()}.txt`;
+        return this.supportFile(folder, newName);
+      });
+  }
+
+  // Create a dump of all pending posts for the different configured deployments
+  public async dumpPendingPosts() {
+
+    var filew:FileWriter;
+    var write = async (s:string) => {
+      if (!filew) {
+        filew = await this.supportFileCreateRotate('pending-posts');
+      }
+      return new Promise<void>( (resolve, reject) => {
+        filew.write(s);
+        resolve();
+      });
+    };
+
+    try {
+      const deployments:Deployment[] = await this.database.getDeployments();
+      for (const deployment of deployments) {
+        const pending:Post[] = await this.database.getPostsPending(deployment);
+        
+        if (pending.length == 0)
+          continue;
+
+        const pendingWithValues:Post[] = 
+          await Promise.all(
+            pending.map(async (p) => {
+              // Hydrate post
+              let f:Form = await this.database.getFormWithAttributes(deployment, p.form_id);
+              p.loadForm([f]);
+              if (p.user_id) {
+                let u:User = await this.database.getUser(deployment, p.user_id);
+                p.loadUser([u]);
+              }
+              let v:Value[] = await this.database.getValues(deployment, p);
+              p.loadValues(v);
+              return p;
+            }));
+        
+        let record:object = {
+          _meta: {
+            info: "Pending posts for configured deployment",
+            when: new Date().toISOString()
+          },
+          deployment: deployment,
+          posts: pendingWithValues
+        }
+        write(JSON.stringify(record) + '\n');
+        this.logger.info(this, 'dumpPendingPosts', record);
+      }
+    } catch(e) {
+      this.logger.error(this, 'dumpPendingPosts', 'Dumping posts', e);
+    }
+  }
+}


### PR DESCRIPTION
On app start, pending posts will be saved to storage as JSON. This is meant as a measure to access pending post data in case it's not correctly synced when online.